### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :search]
   
   def index
-
+    @items = Item.includes(:user) .order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,8 +157,6 @@
           </li>
         <% end %>
       <% else %>
-        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-        <%# 商品がある場合は表示されないようにしましょう %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +174,6 @@
           </div>
           <% end %>
         </li>
-        <%# //商品がある場合は表示されないようにしましょう %>
-        <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <% end %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,57 +127,58 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
+      <% if Item.exists?%>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.delivery_charge_burden.name %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
+        <% end %>
+      <% else %>
+        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <%# 商品がある場合は表示されないようにしましょう %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+        <%# //商品がある場合は表示されないようにしましょう %>
+        <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧表示機能の実装
※売却済みの商品の画像上に「sold out」の文字が表示される機能は未実装です

 # Why
商品一覧表示機能を利用する為

## エビデンス動画
商品のデータがない場合は、ダミー商品が表示されている動画
商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）

上記いずれも以下URLにて確認可能
https://gyazo.com/80d7fa396cde952469a44b54cf9ee1bc

